### PR TITLE
Fixed searching from within documentation-frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/dshub-cognite-docs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Adds the possibility of displaying cognite documentation from within DSHub.",
   "keywords": [
     "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ class CogniteDocFrame extends IFrame {
     CogniteDocFrame.rank += 1;
 
     // We can selectively allow some Sandbox-exceptions. All restrictions are applied by default.
-    this.sandbox = ['allow-same-origin', 'allow-scripts'];
+    this.sandbox = ['allow-same-origin', 'allow-scripts', 'allow-forms'];
   }
 }
 


### PR DESCRIPTION
The issue was that the sandboxed IFrames did not allow for form submission. I now made a sandbox-exception to
include the `allow-forms`. This fixes the issue. 