### PR TITLE
Fixed the focusing of already opened documentation-tabs. 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,9 @@ function initializeDocFrame(
       if (!widget.isAttached) {
         app.shell.add(widget, 'main');
       }
+
+      // If the widget is attached, yet not focused, we refocus it here.
+      app.shell.activateById(widget.id);
       widget.content.update();
     }
   });


### PR DESCRIPTION
Closes #7 

The plugin now correctly refocuses any previously opened tabs. 