### PR TITLE
[Chore] Specify GH-actions environment

### DIFF
--- a/.github/workflows/publish_on_release.yaml
+++ b/.github/workflows/publish_on_release.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: CD
     steps:
       - uses: actions/checkout@v4
       # Setup .npmrc file to publish to npm


### PR DESCRIPTION
We are now using environment secrets. The NPM_Token is in the CD environment. 